### PR TITLE
Replace teal+slate palette with charcoal+slate blue

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -44,7 +44,7 @@ const socialLinks = [
   .hero {
     position: relative;
     overflow: hidden;
-    background: linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%);
+    background: linear-gradient(135deg, #1C1F26 0%, #272B33 50%, #1C1F26 100%);
     padding: var(--space-5xl) var(--space-xl);
     text-align: center;
   }
@@ -58,7 +58,7 @@ const socialLinks = [
   .hero__glow--top {
     width: 800px;
     height: 800px;
-    background: radial-gradient(circle, rgba(13, 148, 136, 0.12) 0%, transparent 70%);
+    background: radial-gradient(circle, rgba(91, 124, 153, 0.10) 0%, transparent 70%);
     top: -400px;
     right: -200px;
   }
@@ -66,7 +66,7 @@ const socialLinks = [
   .hero__glow--bottom {
     width: 600px;
     height: 600px;
-    background: radial-gradient(circle, rgba(13, 148, 136, 0.08) 0%, transparent 70%);
+    background: radial-gradient(circle, rgba(91, 124, 153, 0.07) 0%, transparent 70%);
     bottom: -300px;
     left: -150px;
   }
@@ -88,8 +88,8 @@ const socialLinks = [
     border-radius: 50%;
     object-fit: cover;
     margin: 0 auto;
-    border: 3px solid rgba(13, 148, 136, 0.4);
-    box-shadow: 0 0 40px rgba(13, 148, 136, 0.15), 0 0 80px rgba(13, 148, 136, 0.05);
+    border: 3px solid rgba(91, 124, 153, 0.35);
+    box-shadow: 0 0 40px rgba(91, 124, 153, 0.12), 0 0 80px rgba(91, 124, 153, 0.04);
   }
 
   .hero__name {
@@ -170,7 +170,7 @@ const socialLinks = [
     background: var(--color-accent-light);
     color: #FFFFFF;
     transform: translateY(-1px);
-    box-shadow: 0 4px 20px rgba(13, 148, 136, 0.3);
+    box-shadow: 0 4px 20px rgba(91, 124, 153, 0.25);
   }
 
   .hero__btn--secondary {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,28 +5,28 @@
 
 /* --- Design Tokens --- */
 :root {
-  /* Colors — Teal + Slate palette */
-  --color-bg: #F8FAFC;
+  /* Colors — Charcoal + Slate Blue palette */
+  --color-bg: #FAFAFA;
   --color-surface: #FFFFFF;
-  --color-text: #0F172A;
-  --color-text-secondary: #64748B;
-  --color-text-muted: #94A3B8;
-  --color-accent: #0D9488;
-  --color-accent-light: #14B8A6;
-  --color-accent-hover: #0F766E;
-  --color-accent-bg: #F0FDFA;
-  --color-accent-border: #99F6E4;
-  --color-border: #E2E8F0;
-  --color-border-light: #F1F5F9;
-  --color-dark: #0F172A;
-  --color-dark-secondary: #1E293B;
-  --color-dark-muted: #334155;
-  --color-hero-text: #F8FAFC;
-  --color-hero-muted: #94A3B8;
-  --color-footer-bg: #020617;
-  --color-footer-text: #CBD5E1;
-  --color-amber: #F59E0B;
-  --color-amber-bg: #FFFBEB;
+  --color-text: #1C1F26;
+  --color-text-secondary: #5F6673;
+  --color-text-muted: #8E95A2;
+  --color-accent: #5B7C99;
+  --color-accent-light: #6E8FA8;
+  --color-accent-hover: #496A85;
+  --color-accent-bg: #F0F4F8;
+  --color-accent-border: #C2D1DE;
+  --color-border: #E3E6EB;
+  --color-border-light: #F2F3F5;
+  --color-dark: #1C1F26;
+  --color-dark-secondary: #272B33;
+  --color-dark-muted: #3A3F4B;
+  --color-hero-text: #F5F5F5;
+  --color-hero-muted: #9CA3AF;
+  --color-footer-bg: #111318;
+  --color-footer-text: #C5C9D0;
+  --color-amber: #D4913B;
+  --color-amber-bg: #FBF7F0;
 
   /* Typography */
   --font-heading: 'Plus Jakarta Sans', 'Inter', system-ui, -apple-system, sans-serif;
@@ -203,7 +203,7 @@ strong {
 .prose a {
   color: var(--color-accent);
   text-decoration: underline;
-  text-decoration-color: rgba(13, 148, 136, 0.3);
+  text-decoration-color: rgba(91, 124, 153, 0.3);
   text-underline-offset: 3px;
   transition: text-decoration-color var(--transition-fast);
 }


### PR DESCRIPTION
Swap the saturated teal accent colors for muted slate blue tones and warm charcoal darks. Updates CSS tokens and all hardcoded rgba values in the Hero component for a more understated, natural feel.

https://claude.ai/code/session_01C3K9ibWs3nQ56bEBXf54ai