### PR TITLE
Refactor typography system: switch heading font to Lora serif

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -68,7 +68,7 @@ const year = new Date().getFullYear();
     background: var(--color-accent);
     color: #fff;
     font-family: var(--font-heading);
-    font-weight: 800;
+    font-weight: 700;
     font-size: 0.75rem;
     border-radius: 6px;
   }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -93,7 +93,7 @@ const currentPath = Astro.url.pathname;
     background: var(--color-accent);
     color: #fff;
     font-family: var(--font-heading);
-    font-weight: 800;
+    font-weight: 700;
     font-size: 0.85rem;
     border-radius: var(--radius-sm);
     letter-spacing: 0;
@@ -112,7 +112,7 @@ const currentPath = Astro.url.pathname;
   }
 
   .header__link {
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 0.88rem;
     font-weight: 500;
     color: var(--color-text-secondary);

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -95,15 +95,15 @@ const socialLinks = [
   .hero__name {
     font-family: var(--font-heading);
     font-size: 3rem;
-    font-weight: 800;
+    font-weight: 700;
     color: #FFFFFF;
-    letter-spacing: -0.03em;
+    letter-spacing: -0.01em;
     margin-bottom: var(--space-sm);
     line-height: 1.1;
   }
 
   .hero__tagline {
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 1.15rem;
     font-weight: 500;
     color: var(--color-accent-light);
@@ -152,7 +152,7 @@ const socialLinks = [
   }
 
   .hero__btn {
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 0.9rem;
     font-weight: 600;
     padding: 12px 28px;

--- a/src/components/PublicationCard.astro
+++ b/src/components/PublicationCard.astro
@@ -90,7 +90,7 @@ const cleanVenue = venue.replace(/&amp;/g, '&');
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 0.78rem;
     font-weight: 600;
     color: var(--color-accent);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,7 +31,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Inter:wght@300;400;500;600;700&family=Lora:ital,wght@0,400;0,600;1,400&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Inter:wght@300;400;500;600;700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap"
     rel="stylesheet"
   />
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -25,11 +25,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .not-found__code {
     font-family: var(--font-heading);
     font-size: 6rem;
-    font-weight: 800;
+    font-weight: 700;
     color: var(--color-border);
     line-height: 1;
     margin-bottom: var(--space-md);
-    letter-spacing: -0.03em;
+    letter-spacing: -0.01em;
   }
 
   .not-found__title {
@@ -47,7 +47,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     display: inline-flex;
     align-items: center;
     gap: var(--space-sm);
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 0.9rem;
     color: var(--color-accent);

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -74,8 +74,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .cv-page__title {
     font-family: var(--font-heading);
     font-size: 2.5rem;
-    font-weight: 800;
-    letter-spacing: -0.03em;
+    font-weight: 700;
+    letter-spacing: -0.01em;
     margin-bottom: var(--space-lg);
   }
 
@@ -91,7 +91,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     padding: 12px 24px;
     background: var(--color-accent);
     color: #ffffff;
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 0.9rem;
     border-radius: var(--radius-full);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,9 +142,9 @@ const featured = allPubs
   .highlight-number {
     font-family: var(--font-heading);
     font-size: 2rem;
-    font-weight: 800;
+    font-weight: 700;
     color: var(--color-accent);
-    letter-spacing: -0.03em;
+    letter-spacing: -0.01em;
     line-height: 1;
     margin-bottom: var(--space-sm);
   }
@@ -152,7 +152,7 @@ const featured = allPubs
   .highlight-badge {
     font-family: var(--font-heading);
     font-size: 1.5rem;
-    font-weight: 800;
+    font-weight: 700;
     color: var(--color-accent);
     letter-spacing: 0.05em;
     line-height: 1;
@@ -167,7 +167,7 @@ const featured = allPubs
   }
 
   .highlight-label {
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 0.82rem;
     font-weight: 600;
     color: var(--color-text-secondary);
@@ -190,7 +190,7 @@ const featured = allPubs
     display: inline-flex;
     align-items: center;
     gap: var(--space-sm);
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-weight: 600;
     font-size: 0.95rem;
     color: var(--color-accent);

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -100,8 +100,8 @@ const contributing = sorted.filter((p) => !p.data.firstAuthor);
   .pub-page__title {
     font-family: var(--font-heading);
     font-size: 2.5rem;
-    font-weight: 800;
-    letter-spacing: -0.03em;
+    font-weight: 700;
+    letter-spacing: -0.01em;
     margin-bottom: var(--space-sm);
   }
 
@@ -171,7 +171,7 @@ const contributing = sorted.filter((p) => !p.data.firstAuthor);
   .presentation__badge {
     flex-shrink: 0;
     height: fit-content;
-    font-family: var(--font-heading);
+    font-family: var(--font-sans);
     font-size: 0.7rem;
     font-weight: 700;
     text-transform: uppercase;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,7 +29,7 @@
   --color-amber-bg: #FBF7F0;
 
   /* Typography */
-  --font-heading: 'Plus Jakarta Sans', 'Inter', system-ui, -apple-system, sans-serif;
+  --font-heading: 'Lora', Georgia, 'Times New Roman', serif;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-serif: 'Lora', Georgia, serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
@@ -118,7 +118,7 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.25;
   font-weight: 700;
   color: var(--color-text);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.01em;
 }
 
 h1 { font-size: 2.5rem; }
@@ -162,7 +162,7 @@ strong {
   display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
-  font-family: var(--font-heading);
+  font-family: var(--font-sans);
   font-size: 0.78rem;
   font-weight: 700;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
This PR refactors the typography system to improve visual hierarchy and readability by changing the heading font from Plus Jakarta Sans to Lora serif, while adjusting font weights and letter spacing across the site.

## Key Changes
- **Font family update**: Changed `--font-heading` from 'Plus Jakarta Sans' to 'Lora' serif in global styles
- **Font weight reduction**: Reduced heading font weights from 800 to 700 across all components (Hero, pages, headers, footers)
- **Letter spacing adjustment**: Tightened letter spacing on large headings from -0.03em to -0.01em for better visual balance with the serif font
- **Font family reassignments**: Changed secondary text elements (labels, buttons, badges, links) from heading font to `--font-sans` (Inter) for improved readability:
  - Hero tagline and buttons
  - Highlight labels and badges
  - Navigation links and buttons
  - Publication badges and metadata
  - CV and 404 page buttons
- **Google Fonts update**: Updated font import to include Lora weights (400, 500, 600, 700) and italic variants (400, 600)
- **Global heading styles**: Adjusted default heading letter spacing from -0.02em to -0.01em

## Implementation Details
The changes maintain visual hierarchy while creating a more sophisticated aesthetic by using serif fonts for primary headings and sans-serif for supporting text. The reduced font weight (700 vs 800) combined with the serif typeface provides better readability without sacrificing prominence. All changes are consistent across the site's components and pages.

https://claude.ai/code/session_014a64KH7e47tT4JZofne6L2