### PR TITLE
Update credentials and bio to reflect MD completion

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -113,10 +113,11 @@ const socialLinks = [
   }
 
   .hero__affiliations {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     color: var(--color-hero-muted);
     margin-bottom: var(--space-xl);
     line-height: 1.6;
+    white-space: nowrap;
   }
 
   .hero__dot {
@@ -202,6 +203,7 @@ const socialLinks = [
 
     .hero__affiliations {
       font-size: 0.85rem;
+      white-space: normal;
     }
 
     .hero__affiliations span:not(.hero__dot) {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -14,8 +14,8 @@ const socialLinks = [
     <div class="hero__photo">
       <img src="/images/WhiteCoat.jpg" alt="Kumar Thurimella" width="180" height="180" loading="eager" />
     </div>
-    <h1 class="hero__name">Kumar Thurimella, PhD</h1>
-    <p class="hero__tagline">Incoming Internal Medicine Resident · Physician-Scientist in Training</p>
+    <h1 class="hero__name">Kumar Thurimella, MD, PhD</h1>
+    <p class="hero__tagline">Incoming Internal Medicine Resident · Physician-Scientist</p>
     <div class="hero__affiliations">
       <span>Stanford Health Care (Incoming)</span>
       <span class="hero__dot">&middot;</span>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -17,7 +17,7 @@ const socialLinks = [
     <h1 class="hero__name">Kumar Thurimella, MD, PhD</h1>
     <p class="hero__tagline">Incoming Internal Medicine Resident · Physician-Scientist</p>
     <div class="hero__affiliations">
-      <span>Stanford Health Care (Incoming)</span>
+      <span>Stanford Health Care</span>
       <span class="hero__dot">&middot;</span>
       <span>University of Colorado School of Medicine</span>
       <span class="hero__dot">&middot;</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'Kumar Thurimella, PhD — Final-year MD student at Colorado, PhD from Cambridge. Computational biology, microbiome research, and applied mathematics.' } = Astro.props;
+const { title, description = 'Kumar Thurimella, MD, PhD — MD from the University of Colorado, PhD from the University of Cambridge. Physician-scientist working at the intersection of AI, computational biology, and clinical medicine.' } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="CV — Kumar Thurimella, PhD" description="Curriculum Vitae for Kumar Thurimella, PhD — Final-year MD student at Colorado, PhD from Cambridge.">
+<BaseLayout title="CV — Kumar Thurimella, MD, PhD" description="Curriculum Vitae for Kumar Thurimella, MD, PhD — MD from the University of Colorado, PhD from the University of Cambridge.">
   <section class="cv-page">
     <div class="container">
       <div class="cv-page__header">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const featured = allPubs
   .slice(0, 4);
 ---
 
-<BaseLayout title="Kumar Thurimella, PhD — Physician-Scientist">
+<BaseLayout title="Kumar Thurimella, MD, PhD — Physician-Scientist">
   <Hero />
 
   <!-- About -->
@@ -22,7 +22,7 @@ const featured = allPubs
       <h2 class="section-title">About</h2>
       <div class="prose">
         <p>
-          I am a final-year MD student at the <strong>University of Colorado School of Medicine</strong> and recently completed my PhD at the <strong>University of Cambridge</strong>. This summer, I will begin Internal Medicine residency at <strong>Stanford Health Care</strong> on the <strong>ABIM Research Pathway (Short Track)</strong>, with a guaranteed <strong>Rheumatology fellowship</strong> at Stanford to follow. Before medical school, I worked as a software engineer at <strong>Uber</strong>, where I first saw the potential of computation to find precise signals within vast, complex systems. That conviction — that algorithms could help unravel the mechanisms behind autoimmune disease — led me to pursue a career as a physician-scientist.
+          I recently earned my <strong>MD</strong> from the <strong>University of Colorado School of Medicine</strong> and my <strong>PhD</strong> from the <strong>University of Cambridge</strong>. This summer, I begin Internal Medicine residency at <strong>Stanford Health Care</strong> on the <strong>ABIM Research Pathway (Short Track)</strong>, with a guaranteed <strong>Rheumatology fellowship</strong> at Stanford to follow. Before medical school, I was a software engineer at <strong>Uber</strong>, where I first saw how computation could surface precise signals within vast, complex systems — a conviction that drew me toward a career as a physician-scientist.
         </p>
         <p>
           My work sits at the intersection of <strong>AI</strong>, <strong>computational biology</strong>, and <strong>clinical medicine</strong>. I am drawn to <strong>rheumatology</strong>, where immune dysregulation, complex patient data, and computational modeling converge with the opportunity to develop targeted therapies for patients who need them most.
@@ -75,7 +75,7 @@ const featured = allPubs
           At the <strong>University of Colorado School of Medicine</strong>, I earned Honors in all six core clinical clerkships — Internal Medicine, OB/GYN, Pediatrics, Family Medicine, Psychiatry, and Surgery — as well as in my Rheumatology and Medicine Acting Internship rotations. I was elected to <strong>Alpha Omega Alpha (AOA)</strong>, the national medical honor society.
         </p>
         <p>
-          I will continue my clinical training at <strong>Stanford Health Care</strong>, where I matched into Internal Medicine on the <strong>ABIM Research Pathway (Short Track)</strong>, beginning June 2026. The pathway leads directly into a guaranteed <strong>Rheumatology fellowship</strong> at Stanford starting in 2028, allowing me to integrate rigorous clinical training with protected research time as I build a career as a physician-scientist focused on autoimmune disease.
+          I continue my clinical training at <strong>Stanford Health Care</strong>, where I matched into Internal Medicine on the <strong>ABIM Research Pathway (Short Track)</strong>, beginning June 2026. The pathway leads directly into a guaranteed <strong>Rheumatology fellowship</strong> at Stanford starting in 2028, allowing me to integrate rigorous clinical training with protected research time as I build a career as a physician-scientist focused on autoimmune disease.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Updated Kumar's professional credentials and biographical content across the site to reflect the completion of his MD degree from the University of Colorado School of Medicine. All references have been updated from "final-year MD student" to "MD, PhD" holder.

## Key Changes
- **Page titles and headings**: Updated credentials from "PhD" to "MD, PhD" in the main page title, hero section, CV page, and meta descriptions
- **Hero section**: 
  - Changed name display from "Kumar Thurimella, PhD" to "Kumar Thurimella, MD, PhD"
  - Updated tagline from "Physician-Scientist in Training" to "Physician-Scientist"
- **About section**: Rewrote the opening paragraph to reflect current status:
  - Changed from "final-year MD student" to "recently earned my MD"
  - Updated tense from future ("will begin") to present ("begin")
  - Refined language for clarity and flow
- **Education section**: Updated clinical training description from future tense ("will continue") to present tense ("continue")
- **Meta descriptions**: Updated default page description to reflect completed degrees and current focus areas (AI, computational biology, clinical medicine)

## Implementation Details
All changes maintain consistency across multiple files (index.astro, Hero.astro, BaseLayout.astro, cv.astro) to ensure the site accurately represents Kumar's current professional status and credentials.

https://claude.ai/code/session_01NADD8YPdrHGKgnKVLGWKvd