### PR TITLE
Update site copy & metadata to reflect current residency; add Research Questions and publication improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kthurimella.github.io
 
-Personal website for Kumar Thurimella — MD/PhD Candidate at the University of Colorado School of Medicine and the University of Cambridge.
+Personal website for Kumar Thurimella, MD, PhD, an Internal Medicine resident and physician-scientist at Stanford Health Care.
 
 Built with [Astro](https://astro.build/).
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,7 +15,7 @@ const socialLinks = [
       <img src="/images/WhiteCoat.jpg" alt="Kumar Thurimella" width="180" height="180" loading="eager" />
     </div>
     <h1 class="hero__name">Kumar Thurimella, MD, PhD</h1>
-    <p class="hero__tagline">Internal Medicine Resident (TIP)· Physician Scientist</p>
+    <p class="hero__tagline">Internal Medicine Resident &middot; Physician-Scientist</p>
     <div class="hero__affiliations">
       <span>Stanford Health Care</span>
       <span class="hero__dot">&middot;</span>
@@ -37,7 +37,7 @@ const socialLinks = [
     </div>
     <div class="hero__cta">
       <a href="#research" class="hero__btn hero__btn--primary">View Research</a>
-      <a href="/cv/" class="hero__btn hero__btn--secondary">Download CV</a>
+      <a href="/cv/" class="hero__btn hero__btn--secondary">View CV</a>
     </div>
   </div>
 </section>

--- a/src/components/PublicationCard.astro
+++ b/src/components/PublicationCard.astro
@@ -6,10 +6,11 @@ interface Props {
   excerpt: string;
   citation: string;
   paperurl?: string;
+  firstAuthor?: boolean;
   slug: string;
 }
 
-const { title, venue, date, excerpt, citation, paperurl, slug } = Astro.props;
+const { title, venue, date, excerpt, citation, paperurl, firstAuthor = false, slug } = Astro.props;
 const year = date.getFullYear();
 
 // Clean venue of HTML entities for display
@@ -37,6 +38,7 @@ const cleanVenue = venue.replace(/&amp;/g, '&');
       title
     )}
   </h3>
+  {firstAuthor && <span class="pub-card__authorship">First-author work</span>}
   <p class="pub-card__excerpt">{excerpt}</p>
   <p class="pub-card__citation" set:html={citation} />
 </article>
@@ -123,6 +125,21 @@ const cleanVenue = venue.replace(/&amp;/g, '&');
 
   .pub-card__title a:hover {
     color: var(--color-accent);
+  }
+
+  .pub-card__authorship {
+    display: inline-flex;
+    width: fit-content;
+    margin-bottom: var(--space-sm);
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    background: var(--color-accent-bg);
+    border: 1px solid var(--color-accent-border);
+    color: var(--color-accent);
+    font-family: var(--font-sans);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
   }
 
   .pub-card__excerpt {

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -3,7 +3,7 @@ const items = [
   {
     title: 'Internal Medicine Residency, ABIM Research Pathway',
     subtitle: 'Stanford Health Care',
-    detail: 'Short Track · Rheumatology Fellowship at Stanford, 2028–',
+    detail: 'ABIM Research Pathway · Planned Rheumatology training at Stanford',
     link: 'https://med.stanford.edu/medicine.html',
     period: '2026–2028',
   },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'Kumar Thurimella, MD, PhD — MD from the University of Colorado, PhD from the University of Cambridge. Physician-scientist working at the intersection of AI, computational biology, and clinical medicine.' } = Astro.props;
+const { title, description = 'Kumar Thurimella, MD, PhD, is an Internal Medicine resident and physician-scientist at Stanford Health Care whose work spans machine learning, computational biology, human immunology, and immune-mediated disease.' } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
 const ogImage = new URL('/images/WhiteCoat.jpg', Astro.site).toString();
@@ -20,7 +20,7 @@ const personSchema = {
   alternateName: ['Kumar Thurimella, MD, PhD', 'Dr. Kumar Thurimella'],
   url: 'https://kthurimella.github.io/',
   image: ogImage,
-  jobTitle: 'Physician-Scientist, Incoming Internal Medicine Resident',
+  jobTitle: 'Internal Medicine Resident and Physician-Scientist',
   description,
   alumniOf: [
     {
@@ -40,11 +40,13 @@ const personSchema = {
     sameAs: 'https://stanfordhealthcare.org/',
   },
   knowsAbout: [
-    'Rheumatology',
     'Internal Medicine',
+    'Rheumatology',
+    'Computational Immunology',
     'Computational Biology',
     'Protein Language Models',
     'Artificial Intelligence in Medicine',
+    'Autoimmune Disease',
     'Microbiome',
   ],
   sameAs: [
@@ -71,6 +73,7 @@ const personSchema = {
   <meta property="og:type" content={isHome ? 'profile' : 'website'} />
   <meta property="og:url" content={canonicalURL} />
   <meta property="og:site_name" content="Kumar Thurimella" />
+  <!-- TODO: Consider replacing the headshot with a dedicated 1200 × 630 social preview card. -->
   <meta property="og:image" content={ogImage} />
   {isHome && <Fragment>
     <meta property="profile:first_name" content="Kumar" />
@@ -101,7 +104,7 @@ const personSchema = {
     <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   )}
 
-  <!-- Google Analytics -->
+  <!-- Google Analytics: two GA4 measurement IDs are configured; repository history does not clarify whether both are required, so both are retained for owner review. -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-J7QJ4YLK8C"></script>
   <script is:inline>
     window.dataLayer = window.dataLayer || [];

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -2,14 +2,14 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
-<BaseLayout title="CV — Kumar Thurimella, MD, PhD" description="Curriculum Vitae for Kumar Thurimella, MD, PhD — MD from the University of Colorado, PhD from the University of Cambridge.">
+<BaseLayout title="CV — Kumar Thurimella, MD, PhD" description="Curriculum Vitae for Kumar Thurimella, MD, PhD, Internal Medicine resident and physician-scientist at Stanford Health Care.">
   <section class="cv-page">
     <div class="container">
       <div class="cv-page__header">
         <span class="section-label">Curriculum Vitae</span>
         <h1 class="cv-page__title">CV</h1>
         <div class="cv-actions">
-          <a href="/files/KumarThurimella_CV.pdf" class="cv-download" download>
+          <a href="/files/KT_CV.pdf" class="cv-download" download>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" /></svg>
             Download PDF
           </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,10 +22,10 @@ const featured = allPubs
       <h2 class="section-title">About</h2>
       <div class="prose">
         <p>
-          I recently earned my <strong>MD</strong> from the <strong>University of Colorado School of Medicine</strong> and my <strong>PhD</strong> from the <strong>University of Cambridge</strong>. This summer, I begin Internal Medicine residency at <strong>Stanford Health Care</strong> on the <strong>ABIM Research Pathway (Short Track)</strong>, with a guaranteed <strong>Rheumatology fellowship</strong> at Stanford to follow. Before medical school, I was a software engineer at <strong>Uber</strong>, where I first saw how computation could surface precise signals within vast, complex systems — a conviction that drew me toward a career as a physician-scientist.
+          I am an <strong>Internal Medicine resident</strong> and <strong>physician-scientist</strong> at <strong>Stanford Health Care</strong>, training through the <strong>ABIM Research Pathway</strong> with plans to specialize in <strong>Rheumatology</strong>. My research combines machine learning, human immunology, and clinical data to understand immune-mediated disease and develop more precise approaches to diagnosis and treatment.
         </p>
         <p>
-          My work sits at the intersection of <strong>AI</strong>, <strong>computational biology</strong>, and <strong>clinical medicine</strong>. I am drawn to <strong>rheumatology</strong>, where immune dysregulation, complex patient data, and computational modeling converge with the opportunity to develop targeted therapies for patients who need them most.
+          I earned my <strong>MD</strong> from the <strong>University of Colorado School of Medicine</strong> and my <strong>PhD</strong> from the <strong>University of Cambridge</strong>, where I was a <strong>Gates Cambridge Scholar</strong>. Before medical school, I was a software engineer at <strong>Uber</strong>, an experience that shaped my interest in finding meaningful signals within complex systems and helped draw me from computation toward medicine and biological discovery.
         </p>
       </div>
     </div>
@@ -35,16 +35,43 @@ const featured = allPubs
   <section id="research" class="section fade-in">
     <div class="container container--narrow">
       <span class="section-label">Research</span>
-      <h2 class="section-title">Current Work</h2>
+      <h2 class="section-title">Doctoral Research</h2>
       <div class="prose">
         <p>
-          My PhD in <strong>Biotechnology and Statistics/Deep Learning</strong> focuses on using protein lanugage models to discover new microbial enzymes linked in immune mediated diseases. I was advised by <a href="http://www.statslab.cam.ac.uk/~sb2116/" target="_blank" rel="noopener noreferrer">Dr. Sergio Bacallado</a> at <strong>Cambridge</strong> and <a href="https://www.broadinstitute.org/xavier-lab" target="_blank" rel="noopener noreferrer">Dr. Ramnik Xavier</a> at the <strong>Broad Institute</strong> and <strong>Mass General Hospital</strong>.
+          My Cambridge PhD in <strong>Biotechnology and Statistics/Deep Learning</strong> used <strong>protein language models</strong> to discover microbial enzymes and microbial protease allergens implicated in immune-mediated disease. I was advised by <a href="http://www.statslab.cam.ac.uk/~sb2116/" target="_blank" rel="noopener noreferrer">Dr. Sergio Bacallado</a> at <strong>Cambridge</strong> and <a href="https://www.broadinstitute.org/xavier-lab" target="_blank" rel="noopener noreferrer">Dr. Ramnik Xavier</a> at the <strong>Broad Institute</strong> and <strong>Mass General Hospital</strong>.
         </p>
         <p>
-          My newest paper, <a href="https://www.cell.com/cell-systems/fulltext/S2405-4712(25)00343-6" target="_blank" rel="noopener noreferrer">Identifying microbial protease allergens through protein language model-guided homology</a>, was just published in <em>Cell Systems</em> (2026). It introduces a deep learning framework using protein language models to uncover candidate allergenic serine proteases across gut and oral microbiome gene catalogs. The work was recently <a href="https://www.ceb.cam.ac.uk/news/hidden-allergens-microbiome" target="_blank" rel="noopener noreferrer">profiled by the Cambridge Department of Chemical Engineering and Biotechnology</a>. Other recent work includes <a href="https://link.springer.com/article/10.1186/s12859-025-06286-y" target="_blank" rel="noopener noreferrer">CAZyLingua</a>, a protein language model-based tool for annotating carbohydrate-active enzymes in metagenomics (<em>BMC Bioinformatics</em>, 2025).
+          My newest paper, <a href="https://www.cell.com/cell-systems/fulltext/S2405-4712(25)00343-6" target="_blank" rel="noopener noreferrer">Identifying microbial protease allergens through protein language model-guided homology</a>, was published in <em>Cell Systems</em> (2026). It introduces a deep learning framework using protein language models to uncover candidate allergenic serine proteases across gut and oral microbiome gene catalogs. The work was recently <a href="https://www.ceb.cam.ac.uk/news/hidden-allergens-microbiome" target="_blank" rel="noopener noreferrer">profiled by the Cambridge Department of Chemical Engineering and Biotechnology</a>. Other recent work includes <a href="https://link.springer.com/article/10.1186/s12859-025-06286-y" target="_blank" rel="noopener noreferrer">CAZyLingua</a>, a protein language model-based tool for annotating carbohydrate-active enzymes in metagenomics (<em>BMC Bioinformatics</em>, 2025).
+        </p>
+        <h3>Emerging Research Interests</h3>
+        <p>
+          I am interested in using machine learning, high-dimensional human data, and mechanistic immunology to understand pathogenic immune responses in autoimmune disease and identify clinically actionable biomarkers and therapeutic targets.
+        </p>
         <p>
           I am grateful to the <a href="https://www.gatescambridge.org/biography/17712/" target="_blank" rel="noopener noreferrer">Gates Cambridge Scholarship</a> and <a href="https://www.rotary.org/en/our-programs/scholarships" target="_blank" rel="noopener noreferrer">Rotary International Scholarship</a> for funding my PhD.
         </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Research Questions -->
+  <section class="section fade-in">
+    <div class="container">
+      <span class="section-label">Research Questions</span>
+      <h2 class="section-title">Research Questions</h2>
+      <div class="question-grid">
+        <article class="question-card">
+          <h3>How can machine learning reveal disease-relevant protein function?</h3>
+          <p>Developing protein-language-model approaches to identify microbial enzymes, antigens, and other biologically meaningful proteins at scale.</p>
+        </article>
+        <article class="question-card">
+          <h3>How do pathogenic immune responses evolve in human autoimmune disease?</h3>
+          <p>Studying the cellular and molecular programs that shape immune recognition, inflammation, and tissue injury.</p>
+        </article>
+        <article class="question-card">
+          <h3>How can computational discoveries become clinically actionable?</h3>
+          <p>Connecting mechanistic models with patient phenotypes, biomarkers, therapeutic response, and target discovery.</p>
+        </article>
       </div>
     </div>
   </section>
@@ -67,7 +94,7 @@ const featured = allPubs
           <div class="highlight-icon">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>
           </div>
-          <div class="highlight-label">Rheumatology Interest</div>
+          <div class="highlight-label">Rheumatology Pathway</div>
         </div>
       </div>
       <div class="prose">
@@ -75,7 +102,7 @@ const featured = allPubs
           At the <strong>University of Colorado School of Medicine</strong>, I earned Honors in all six core clinical clerkships — Internal Medicine, OB/GYN, Pediatrics, Family Medicine, Psychiatry, and Surgery — as well as in my Rheumatology and Medicine Acting Internship rotations. I was elected to <strong>Alpha Omega Alpha (AOA)</strong>, the national medical honor society.
         </p>
         <p>
-          I continue my clinical training at <strong>Stanford Health Care</strong>, where I matched into Internal Medicine on the <strong>ABIM Research Pathway (Short Track)</strong>, beginning June 2026. The pathway leads directly into a guaranteed <strong>Rheumatology fellowship</strong> at Stanford starting in 2028, allowing me to integrate rigorous clinical training with protected research time as I build a career as a physician-scientist focused on autoimmune disease.
+          I am now an <strong>Internal Medicine resident</strong> at <strong>Stanford Health Care</strong>, training through the <strong>ABIM Research Pathway</strong> with planned subspecialty training in <strong>Rheumatology</strong> at Stanford. My long-term goal is to combine rigorous clinical training with research in autoimmune disease as a physician-scientist.
         </p>
       </div>
     </div>
@@ -97,6 +124,7 @@ const featured = allPubs
             excerpt={pub.data.excerpt}
             citation={pub.data.citation}
             paperurl={pub.data.paperurl}
+            firstAuthor={pub.data.firstAuthor}
             slug={pub.id}
           />
         ))}
@@ -112,6 +140,43 @@ const featured = allPubs
 </BaseLayout>
 
 <style>
+
+  /* Research Questions Grid */
+  .question-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-md);
+  }
+
+  .question-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
+  }
+
+  .question-card:hover {
+    border-color: var(--color-accent-border);
+    box-shadow: var(--shadow-sm);
+    transform: translateY(-1px);
+  }
+
+  .question-card h3 {
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    line-height: 1.4;
+    margin-bottom: var(--space-sm);
+    letter-spacing: -0.01em;
+  }
+
+  .question-card p {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0;
+  }
+
   /* Clinical Highlights Grid */
   .clinical-highlights {
     display: grid;
@@ -203,7 +268,8 @@ const featured = allPubs
   }
 
   @media (max-width: 768px) {
-    .clinical-highlights {
+    .clinical-highlights,
+    .question-grid {
       grid-template-columns: 1fr;
     }
 

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -32,6 +32,7 @@ const contributing = sorted.filter((p) => !p.data.firstAuthor);
               excerpt={pub.data.excerpt}
               citation={pub.data.citation}
               paperurl={pub.data.paperurl}
+              firstAuthor={pub.data.firstAuthor}
               slug={pub.id}
             />
           ))}
@@ -79,6 +80,7 @@ const contributing = sorted.filter((p) => !p.data.firstAuthor);
               excerpt={pub.data.excerpt}
               citation={pub.data.citation}
               paperurl={pub.data.paperurl}
+              firstAuthor={pub.data.firstAuthor}
               slug={pub.id}
             />
           ))}


### PR DESCRIPTION
### Motivation
- Bring all public-facing site copy and structured data up to date to reflect Kumar Thurimella as a current Internal Medicine resident at Stanford Health Care in the ABIM Research Pathway and to refine the narrative connecting his computational PhD work with emerging immunology and rheumatology research interests.
- Preserve existing visual design and clinical honors while correcting content typos, malformed markup, and improving discoverability of publication metadata.

### Description
- Updated homepage copy and structure in `src/pages/index.astro` to lead with Kumar’s current identity, split research into "Doctoral Research" and "Emerging Research Interests", corrected the `protein lanugage models` typo, fixed malformed paragraph markup, added a responsive "Research Questions" section, and renamed the clinical card to `Rheumatology Pathway` while removing dated/future-tense residency language.
- Refined the hero and CV behavior in `src/components/Hero.astro` by changing the tagline to `Internal Medicine Resident · Physician-Scientist`, removing the unexplained "TIP" acronym, hyphenating "Physician-Scientist", and changing the CV button label to `View CV` because `/cv/` serves a page.
- Improved publication presentation by passing and displaying first-author status in `src/components/PublicationCard.astro` and updating callers in `src/pages/index.astro` and `src/pages/publications.astro` to forward `firstAuthor` (keeps venue, year, excerpt, citation, and paper links intact).
- Updated structured data and metadata in `src/layouts/BaseLayout.astro` (default description, `jobTitle`, `knowsAbout`, Open Graph/Twitter notes) and added a TODO recommending a dedicated 1200×630 social preview; left both GA4 measurement IDs in place and added a code comment requesting owner review.
- Minor updates: timeline wording in `src/components/Timeline.astro`, CV page description and PDF link in `src/pages/cv.astro`, and README opening line in `README.md` to remove "MD/PhD Candidate" language.

### Testing
- Ran `npm run build` and verified the static site built successfully with 4 pages generated (`/index`, `/cv`, `/publications`, `/404`). (succeeded)
- Performed repository-wide content checks using `rg` for outdated phrases (`incoming`, `this summer`, `beginning June 2026`, `MD/PhD Candidate`, `Physician Scientist`, `lanugage`) and confirmed no matches remain. (succeeded)
- Fetched the running dev homepage via `curl` to confirm the rendered HTML contains the updated hero tagline, Research Questions section, clinical honors, first-author badges, `View CV` label, and updated OG/Twitter metadata and schema. (succeeded)
- Attempted automated visual screenshots with Playwright but the environment could not install `playwright` due to npm registry access restrictions, so screenshot capture did not run here. (skipped — environment limitation)
- Attempted to create a GitHub PR via `gh` but CLI authentication is unavailable in this environment, so PR creation must be performed from a developer machine or CI with credentials. (skipped — auth required)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a736e022f408323bc9c53d72528934a)